### PR TITLE
Adds dockerfile and github workflow action to auto-build package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*.pdb
+*.Development.json
+**bin
+**obj

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,12 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}/beattogether-unified-server
 
 jobs:
   docker:
+    permissions:
+      packages: write
     name: GitHub Packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Docker
+on: push
+jobs:
+  docker:
+    name: GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/walzen-group/BeatTogether.UnifiedServer/beat-together-unified-server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,12 @@
 name: Docker
 on: push
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   docker:
     name: GitHub Packages
@@ -9,7 +16,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/walzen-group/BeatTogether.UnifiedServer/beat-together-unified-server
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,9 +27,10 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/setup-qemu-action@v2
       - uses: docker/build-push-action@v4
         with:

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/linux-arm.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/linux-arm.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\linux-arm\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/linux-arm64.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/linux-arm64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\linux-arm64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/linux-x64.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/linux-x64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\linux-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/osx-arm64.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/osx-arm64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\osx-arm64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/osx-x64.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/osx-x64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\osx-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-arm.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-arm.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\win-arm\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-arm</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-arm64.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\win-arm64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-x64.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\win-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-x86.pubxml
+++ b/BeatTogether.UnifiedServer/Properties/PublishProfiles/win-x86.pubxml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\win-x86\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: Build the .NET application
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /app
+
+# Copy everything from the host machine into the container
+COPY . .
+
+RUN dotnet clean BeatTogether.UnifiedServer.sln -c Release
+
+# Build for linux x64 for now (no multiarch support yet)
+RUN dotnet publish BeatTogether.UnifiedServer.sln -p:PublishReadyToRun=true -p:PublishTrimmed=false -p:TargetFramework=net6.0 -r linux-x64 -o /tmp/out
+
+# Stage 2: Create a new runtime container
+# FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+
+WORKDIR /app
+
+# Copy the published output from the build stage
+COPY --from=build /tmp/out /app
+
+ENTRYPOINT ["/app/BeatTogether.UnifiedServer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@ COPY . .
 RUN dotnet clean BeatTogether.UnifiedServer.sln -c Release
 
 # Build for linux x64 for now (no multiarch support yet)
-RUN dotnet publish BeatTogether.UnifiedServer.sln -p:PublishReadyToRun=true -p:PublishTrimmed=false -p:TargetFramework=net6.0 -r linux-x64 -o /tmp/out
+RUN dotnet publish BeatTogether.UnifiedServer.sln -c Release -p:PublishReadyToRun=true -p:PublishTrimmed=false -p:TargetFramework=net6.0 -r linux-x64 -o /tmp/out
 
 # Stage 2: Create a new runtime container
-# FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
 
 WORKDIR /app


### PR DESCRIPTION
Hi, my use case is that I would like to run the unified server via docker in my environment.

I've added a dockerfile and a github actions workflow run to auto build the unified server.
The workflow file probably needs small adjustments to suit your needs, but I tried to make it similar to the ones you have in the other repos.

The dockerfile uses a basic sdk 6 builder image and copies the output to a dotnet 6.0 runtime image.
I have excluded *.pdb and *.Development.json files.

In my test, the server starts up without issues.

```
2024-08-31 00:04:14 [22:04:14 INF] Starting api server. Url: http://0.0.0.0:8989
```

In case you consider this useful, please merge so i can change my docker image tag to this repo :)